### PR TITLE
Adding fixes to correct problem where the on-boarding text does not a…

### DIFF
--- a/23AndMeClient/GeneticProfileViewController.swift
+++ b/23AndMeClient/GeneticProfileViewController.swift
@@ -17,11 +17,11 @@ class GeneticProfileViewController: UIViewController {
       let alertController = UIAlertController(title: "Genetic Profile", message: "Do you have a completed genetic profile at 23andMe? Note: if you do not have a profile and hit the \"Yes\" option, displays will be erratic", preferredStyle: .Alert)
       
       let noAction = UIAlertAction(title: "No", style: .Cancel) {(action) in println(action)
-        self.navigationController?.popToRootViewControllerAnimated(true)}
+        self.navigationController?.popViewControllerAnimated(true)}
       alertController.addAction(noAction)
       
       let yesAction = UIAlertAction(title: "Yes", style: .Destructive) {(action) in NetworkController.sharedNetworkController.hasProfile = true
-      self.navigationController?.popToRootViewControllerAnimated(true)}
+      self.navigationController?.popViewControllerAnimated(true)}
       alertController.addAction(yesAction)
       
       self.presentViewController(alertController, animated: true) {}

--- a/23AndMeClient/MenuTableViewController.swift
+++ b/23AndMeClient/MenuTableViewController.swift
@@ -14,16 +14,16 @@ class MenuTableViewController: UITableViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-        
+    
+    // ask user if they have a genetic profile through a separate View Controller
+    let gpVC = self.storyboard?.instantiateViewControllerWithIdentifier("GeneticContentVC") as! GeneticProfileViewController
+    self.navigationController?.pushViewController(gpVC, animated: true)
+    
     if (NetworkController.sharedNetworkController.accessToken == nil)
     {
       let toVC = self.storyboard?.instantiateViewControllerWithIdentifier("NewUserVC") as! PageViewController
       self.navigationController?.pushViewController(toVC, animated: true)
     }
-    
-    // ask user if they have a genetic profile through a separate View Controller
-    let gpVC = self.storyboard?.instantiateViewControllerWithIdentifier("GeneticContentVC") as! GeneticProfileViewController
-    self.navigationController?.pushViewController(gpVC, animated: true)
     
   } // viewDidLoad()
   

--- a/23AndMeClient/PageContentViewController.swift
+++ b/23AndMeClient/PageContentViewController.swift
@@ -17,7 +17,7 @@ class PageContentViewController: UIViewController {
   {
     println("next page clicked")
     
-    self.navigationController?.popToRootViewControllerAnimated(true)
+    self.navigationController?.popViewControllerAnimated(true)
   }
   
   let onboardingInfo      = OnboardingData()


### PR DESCRIPTION
…ppear. The corrections affect MenuTableViewController.swift, GeneticProfileViewController.swift, and PageContentViewController.swift:
1. In  MenuTableViewController's viewDidLoad() function, change so "GeneticContentVC" is pushed onto NavigationController's stack before "NewUserVC".
2. In GeneticProfileViewController's viewDidLoad() function, change calls to navigationController.PopToRootViewControllerAnimated() to navigationController.PopViewControllerAnimated()
3. In PageContentViewController's viewDidLoad() function, change call to navigationController.PopToRootViewControllerAnimated() to navigationController.PopViewControllerAnimated()

This corrects the problem of the on-boarding views never appearing and causes the UIAlertView asking if the user has a Genetic Profile to appear after the on-boarding view, which was the original intent.
